### PR TITLE
Update epub stylesheet flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(EPUB_FILE): clean $(CHAPTERS) meta/title.txt meta/cover.jpg meta/stylesheet.cs
 		meta/title.txt \
 		$(CHAPTERS) \
 		--epub-cover-image=meta/cover.jpg \
-		--epub-stylesheet=meta/stylesheet.css \
+		--css=meta/stylesheet.css \
 		--epub-metadata=meta/metadata.xml \
 		--table-of-contents
 


### PR DESCRIPTION
Since the realease of Pandoc 2.0 `--epub-stylesheet` is replaced with `--css`. You can see all the changes to Pandoc [here](https://pandoc.org/releases.html#pandoc-2.0-29-oct-2017).